### PR TITLE
testing meson executable location

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
 test:
   commands:
     - meson -h
+    - meson -v
+    - where meson  # [win]
 
 about:
   home: http://mesonbuild.com


### PR DESCRIPTION
I have a suspicion that on Windows the tests are not actually calling the meson executable in the test environment.  This PR is testing that suspicion.