### PR TITLE
Add @rgommers and @h-vetinari to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SoapZA @dirmeier @pkgw @tschoonj @wolfv
+* @SoapZA @dirmeier @h-vetinari @pkgw @rgommers @tschoonj @wolfv

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Feedstock Maintainers
 
 * [@SoapZA](https://github.com/SoapZA/)
 * [@dirmeier](https://github.com/dirmeier/)
+* [@h-vetinari](https://github.com/h-vetinari/)
 * [@pkgw](https://github.com/pkgw/)
+* [@rgommers](https://github.com/rgommers/)
 * [@tschoonj](https://github.com/tschoonj/)
 * [@wolfv](https://github.com/wolfv/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,3 +53,4 @@ extra:
     - SoapZA
     - wolfv
     - tschoonj
+    - rgommers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,3 +54,4 @@ extra:
     - wolfv
     - tschoonj
     - rgommers
+    - h-vetinari


### PR DESCRIPTION
Hey @conda-forge/meson

@rgommers has been [driving](https://labs.quansight.org/blog/2021/07/moving-scipy-to-meson) the move of scipy from distutils to meson, including _a lot_ of interaction with upstream meson (the switch was [delivered](https://docs.scipy.org/doc/scipy/release.1.9.0.html#scipy-switched-to-meson-as-its-build-system) in scipy 1.9, but a lot of iteration is still happening, and conda-forge hasn't been able to make the switch yet, blocking scipy from dropping the old build system).

I'm supporting him in this primarily on the conda-forge side (e.g. [here](https://github.com/conda-forge/scipy-feedstock/pull/205)), and it would be great if we could help & contribute on the meson-feedstock, resp. accelerate the debugging cycle where necessary by building dev-versions required for as-yet unreleased features into a seperate `meson_dev` label.

Ralf already tried to add himself as a maintainer in #75 / #76, but this didn't seem to be noticed or at least commented on.

Please take a look! :)

Closes #76 
Fixes #75