### PR TITLE
use msvc syntax for flang

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
     - patches/0001-Only-fix-RPATH-if-install_rpath-is-not-empty.patch
     - patches/0002-minimal-adaptations-for-llvm-flang.patch
     - patches/0003-mark-gnu-like-lld-as-not-supporting-rsp.patch
+    - patches/0004-use-msvc-syntax-for-flang.patch
 
 build:
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
   entry_points:

--- a/recipe/patches/0001-Only-fix-RPATH-if-install_rpath-is-not-empty.patch
+++ b/recipe/patches/0001-Only-fix-RPATH-if-install_rpath-is-not-empty.patch
@@ -1,7 +1,7 @@
 From 2c06bf5a82f2ff2c6d071ed168a779cce74e248f Mon Sep 17 00:00:00 2001
 From: Eric Le Bihan <eric.le.bihan.dev@free.fr>
 Date: Sat, 14 Jul 2018 11:18:45 +0200
-Subject: [PATCH 1/3] Only fix RPATH if install_rpath is not empty
+Subject: [PATCH 1/4] Only fix RPATH if install_rpath is not empty
 
 Signed-off-by: Eric Le Bihan <eric.le.bihan.dev@free.fr>
 [Fix: remove leftover from original/unconditional code]

--- a/recipe/patches/0002-minimal-adaptations-for-llvm-flang.patch
+++ b/recipe/patches/0002-minimal-adaptations-for-llvm-flang.patch
@@ -1,7 +1,7 @@
 From 35f010089df188a992c1e994905d130a3e259aff Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 21 Sep 2023 23:49:37 +1100
-Subject: [PATCH 2/3] minimal adaptations for llvm-flang
+Subject: [PATCH 2/4] minimal adaptations for llvm-flang
 
 ---
  mesonbuild/compilers/fortran.py | 9 +++++++--

--- a/recipe/patches/0003-mark-gnu-like-lld-as-not-supporting-rsp.patch
+++ b/recipe/patches/0003-mark-gnu-like-lld-as-not-supporting-rsp.patch
@@ -1,7 +1,7 @@
 From 974bc427642a6bcddacc63c4454d1c0a5d07f52e Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Mon, 25 Sep 2023 09:19:10 +1100
-Subject: [PATCH 3/3] mark gnu-like lld as not supporting rsp
+Subject: [PATCH 3/4] mark gnu-like lld as not supporting rsp
 
 ---
  mesonbuild/linkers/linkers.py | 3 +++

--- a/recipe/patches/0004-use-msvc-syntax-for-flang.patch
+++ b/recipe/patches/0004-use-msvc-syntax-for-flang.patch
@@ -1,0 +1,24 @@
+From 3790454592aef67c625bc8e3aaa1b4b8c8d2c188 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Thu, 28 Sep 2023 22:50:24 +1100
+Subject: [PATCH 4/4] use msvc syntax for flang
+
+---
+ mesonbuild/compilers/fortran.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/mesonbuild/compilers/fortran.py b/mesonbuild/compilers/fortran.py
+index 9915f6912..de1fb9de0 100644
+--- a/mesonbuild/compilers/fortran.py
++++ b/mesonbuild/compilers/fortran.py
+@@ -471,6 +471,10 @@ class FlangFortranCompiler(ClangCompiler, FortranCompiler):
+     def get_module_outdir_args(self, path: str) -> T.List[str]:
+         return ['-module-dir', path]
+ 
++    # try using flang (based on clang-cl) with msvc syntax
++    def get_argument_syntax(self) -> str:
++        return 'msvc'
++
+     def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
+         # We need to apply the search prefix here, as these link arguments may
+         # be passed to a different compiler with a different set of default


### PR DESCRIPTION
Trying to solve the syntax confusion in https://github.com/conda-forge/scipy-feedstock/pull/246.

Presumably as flang is based on the clang driver, when using `clang-cl` we need msvc syntax (certainly to talk to `lld-link`).